### PR TITLE
ef-list-item component specification

### DIFF
--- a/COMPONENT_SPECIFICATIONS/ef-list-item.md
+++ b/COMPONENT_SPECIFICATIONS/ef-list-item.md
@@ -1,0 +1,122 @@
+# ef-list-item
+
+## Description
+
+Render the `li` HTML element for use by these components
+
+ * yet to be determined
+
+
+## Influences
+
+* https://html.spec.whatwg.org/multipage/semantics.html#the-li-element
+* http://v4-alpha.getbootstrap.com/components/list-group/
+* http://purecss.io/menus/
+* http://foundation.zurb.com/sites/docs/navigation.html#basics-menu
+* http://getuikit.com/docs/list.html
+* http://materializecss.com/collections.html
+
+
+## Specification
+
+### HTML element
+
+* <li>
+
+
+### HTML Attributes
+
+These are attribute bindings to properties of the same name
+
+* value
+
+
+### CSS Class
+
+* ef-list-item
+
+
+### CSS Class Name Bindings
+
+These are CSS class name bindings, listed as **property:** *class name applied*
+
+* **active:** *ef-active*
+* **disabled:** *ef-disabled*
+
+
+### Block/Non Block support
+
+* **Block support:** *Yes*
+* **Non-Block support:** *No*
+
+
+## Example Usage
+
+```
+// template
+
+{{#ef-list-item}}
+  Item 1
+{{/ef-list-item}}
+
+// rendered HTML
+
+<li>Item 1</li>
+```
+
+```
+// template
+
+{{#ef-list-item}}
+  {{#link-to "items" 1}}Item 1{{/link-to}}
+{{/ef-list-item}}
+
+// rendered HTML (though with better Ember magic)
+
+<li>
+  <a href="">Item 1</a>
+</li>
+```
+
+
+```
+// template
+
+{{#ef-list-item value="1"}}
+  {{#link-to "items" 1}}Item 1{{/link-to}}
+{{/ef-list-item}}
+
+// rendered HTML (though with better Ember magic)
+
+<li value="1">
+  <a href="">Item 1</a>
+</li>
+```
+
+```
+// template
+
+{{#ef-list-item active=true}}
+  {{#link-to "items" 1}}Item 1{{/link-to}}
+{{/ef-list-item}}
+
+// rendered HTML (though with better Ember magic)
+
+<li class="ef-active">
+  <a href="">Item 1</a>
+</li>
+```
+
+```
+// template
+
+{{#ef-list-item disabled=true}}
+  {{#link-to "items" 1}}Item 1{{/link-to}}
+{{/ef-list-item}}
+
+// rendered HTML (though with better Ember magic)
+
+<li class="ef-disabled">
+  <a href="">Item 1</a>
+</li>
+```

--- a/COMPONENT_SPECIFICATIONS/ef-list-item.md
+++ b/COMPONENT_SPECIFICATIONS/ef-list-item.md
@@ -21,7 +21,7 @@ Render the `li` HTML element for use by these components
 
 ### HTML element
 
-* <li>
+* li
 
 
 ### HTML Attributes

--- a/COMPONENT_SPECIFICATIONS/ef-list-item.md
+++ b/COMPONENT_SPECIFICATIONS/ef-list-item.md
@@ -38,10 +38,10 @@ These are attribute bindings to properties of the same name
 
 ### CSS Class Name Bindings
 
-These are CSS class name bindings, listed as **property:** *class name applied*
+These are CSS class name bindings, listed as **property:** *class name applied* (default state)
 
-* **active:** *ef-active*
-* **disabled:** *ef-disabled*
+* **active:** *ef-active* (defaults to `active: false`)
+* **disabled:** *ef-disabled* (defaults to `disabled: false`)
 
 
 ### Block/Non Block support

--- a/COMPONENT_SPECIFICATIONS/ef-list-item.md
+++ b/COMPONENT_SPECIFICATIONS/ef-list-item.md
@@ -44,6 +44,11 @@ These are CSS class name bindings, listed as **property:** *class name applied* 
 * **disabled:** *ef-disabled* (defaults to `disabled: false`)
 
 
+## Properties
+
+None
+
+
 ### Block/Non Block support
 
 * **Block support:** *Yes*


### PR DESCRIPTION
### Question 1

> If the element is not a child of an ul or menu element: value — Ordinal value of the list item

> The value attribute is processed relative to the element's parent ol element (q.v.), if there is one. If there is not, the attribute has no effect.

https://html.spec.whatwg.org/multipage/semantics.html#the-li-element


Based on the specification above is there an advantage to the component being developed to be aware of the element (i.e. component) it is contained within and only render the `value` attribute if within an `<ol>`?  If so, how is it enforced?  The component is kept from rendering?  Throw errors/warnings in the console?  If only the latter does that add enough value to the developer to justify the overhead of maintaining this component? Seems reasonable to expect a developer to know how to HTML properly


### Question 2

Should there be any logic that keeps the application of the `ef-active` and `ef-disabled` classes, via  the setting of the `active` and `disabled` properties mutually-exclusive?  If so, does one take precedence over the other?  How is it enforced?  The component is kept from rendering?  Throw errors/warnings in the console?  If only the latter does that add enough value to the developer to justify the overhead of maintaining this component?

Both classes being added will not break the component, it will only affect the application of CSS styles based upon the definitions in the companion addon.  Seems reasonable to me to expect devs to have read the documentation and understand how HTML and CSS work.  And by allowing the application of both we are not artificially limiting anyones ability to use this component in a way we have not perceived (as long as doing so is not actually creating a problem for them)